### PR TITLE
feat: added the ELK stack as Docker containers for observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .env
-logs
+logstash_ingest_data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,10 +132,10 @@ services:
       - xpack.security.transport.ssl.verification_mode=certificate
       - xpack.license.self_generated.type=${LICENSE}
     mem_limit: ${ES_MEM_LIMIT}
-    ulimits:
-      memlock:
-        soft: -1
-        hard: -1
+    #ulimits:
+    #  memlock:
+    #    soft: -1
+    #    hard: -1
     healthcheck:
       test:
         [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,21 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - ./logs/database:/var/log/postgresql
-    command: ["postgres", "-c", "logging_collector=on", "-c", "log_directory=/var/log/postgresql", "-c", "log_filename=postgresql.log", "-c", "log_statement=all"]
+      - ./logstash_ingest_data/database:/var/log/postgresql
+    command:
+      [
+        "postgres",
+        "-c",
+        "log_destination=jsonlog",
+        "-c",
+        "logging_collector=on",
+        "-c",
+        "log_directory=/var/log/postgresql",
+        "-c",
+        "log_filename=postgresql.log",
+        "-c",
+        "log_statement=all",
+      ]
 
   evotp3api:
     build: evotp3api
@@ -32,7 +45,194 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - ./logs/backend:/logs
+      - ./logstash_ingest_data/backend:/logs
+
+  setup:
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    volumes:
+      - certs:/usr/share/elasticsearch/config/certs
+    user: "0"
+    command: >
+      bash -c '
+        if [ x${ELASTIC_PASSWORD} == x ]; then
+          echo "Set the ELASTIC_PASSWORD environment variable in the .env file";
+          exit 1;
+        elif [ x${KIBANA_PASSWORD} == x ]; then
+          echo "Set the KIBANA_PASSWORD environment variable in the .env file";
+          exit 1;
+        fi;
+        if [ ! -f config/certs/ca.zip ]; then
+          echo "Creating CA";
+          bin/elasticsearch-certutil ca --silent --pem -out config/certs/ca.zip;
+          unzip config/certs/ca.zip -d config/certs;
+        fi;
+        if [ ! -f config/certs/certs.zip ]; then
+          echo "Creating certs";
+          echo -ne \
+          "instances:\n"\
+          "  - name: es01\n"\
+          "    dns:\n"\
+          "      - es01\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          "  - name: kibana\n"\
+          "    dns:\n"\
+          "      - kibana\n"\
+          "      - localhost\n"\
+          "    ip:\n"\
+          "      - 127.0.0.1\n"\
+          > config/certs/instances.yml;
+          bin/elasticsearch-certutil cert --silent --pem -out config/certs/certs.zip --in config/certs/instances.yml --ca-cert config/certs/ca/ca.crt --ca-key config/certs/ca/ca.key;
+          unzip config/certs/certs.zip -d config/certs;
+        fi;
+        echo "Setting file permissions"
+        chown -R root:root config/certs;
+        find . -type d -exec chmod 750 \{\} \;;
+        find . -type f -exec chmod 640 \{\} \;;
+        echo "Waiting for Elasticsearch availability";
+        until curl -s --cacert config/certs/ca/ca.crt https://es01:9200 | grep -q "missing authentication credentials"; do sleep 30; done;
+        echo "Setting kibana_system password";
+        until curl -s -X POST --cacert config/certs/ca/ca.crt -u "elastic:${ELASTIC_PASSWORD}" -H "Content-Type: application/json" https://es01:9200/_security/user/kibana_system/_password -d "{\"password\":\"${KIBANA_PASSWORD}\"}" | grep -q "^{}"; do sleep 10; done;
+        echo "All done!";
+      '
+    healthcheck:
+      test: ["CMD-SHELL", "[ -f config/certs/es01/es01.crt ]"]
+      interval: 1s
+      timeout: 5s
+      retries: 120
+
+  es01:
+    depends_on:
+      setup:
+        condition: service_healthy
+    image: docker.elastic.co/elasticsearch/elasticsearch:${STACK_VERSION}
+    labels:
+      co.elastic.logs/module: elasticsearch
+    volumes:
+      - certs:/usr/share/elasticsearch/config/certs
+      - esdata01:/usr/share/elasticsearch/data
+    ports:
+      - ${ES_PORT}:9200
+    environment:
+      - node.name=es01
+      - cluster.name=${CLUSTER_NAME}
+      - discovery.type=single-node
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - bootstrap.memory_lock=true
+      - xpack.security.enabled=true
+      - xpack.security.http.ssl.enabled=true
+      - xpack.security.http.ssl.key=certs/es01/es01.key
+      - xpack.security.http.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.http.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.transport.ssl.enabled=true
+      - xpack.security.transport.ssl.key=certs/es01/es01.key
+      - xpack.security.transport.ssl.certificate=certs/es01/es01.crt
+      - xpack.security.transport.ssl.certificate_authorities=certs/ca/ca.crt
+      - xpack.security.transport.ssl.verification_mode=certificate
+      - xpack.license.self_generated.type=${LICENSE}
+    mem_limit: ${ES_MEM_LIMIT}
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s --cacert config/certs/ca/ca.crt https://localhost:9200 | grep -q 'missing authentication credentials'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  kibana:
+    depends_on:
+      es01:
+        condition: service_healthy
+    image: docker.elastic.co/kibana/kibana:${STACK_VERSION}
+    labels:
+      co.elastic.logs/module: kibana
+    volumes:
+      - certs:/usr/share/kibana/config/certs
+      - kibanadata:/usr/share/kibana/data
+    ports:
+      - ${KIBANA_PORT}:5601
+    environment:
+      - SERVERNAME=kibana
+      - ELASTICSEARCH_HOSTS=https://es01:9200
+      - ELASTICSEARCH_USERNAME=kibana_system
+      - ELASTICSEARCH_PASSWORD=${KIBANA_PASSWORD}
+      - ELASTICSEARCH_SSL_CERTIFICATEAUTHORITIES=config/certs/ca/ca.crt
+      - XPACK_SECURITY_ENCRYPTIONKEY=${ENCRYPTION_KEY}
+      - XPACK_ENCRYPTEDSAVEDOBJECTS_ENCRYPTIONKEY=${ENCRYPTION_KEY}
+      - XPACK_REPORTING_ENCRYPTIONKEY=${ENCRYPTION_KEY}
+    mem_limit: ${KB_MEM_LIMIT}
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -s -I http://localhost:5601 | grep -q 'HTTP/1.1 302 Found'",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 120
+
+  metricbeat01:
+    depends_on:
+      es01:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    image: docker.elastic.co/beats/metricbeat:${STACK_VERSION}
+    user: root
+    volumes:
+      - certs:/usr/share/metricbeat/certs
+      - metricbeatdata01:/usr/share/metricbeat/data
+      - "./metricbeat.yml:/usr/share/metricbeat/metricbeat.yml:ro"
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - "/sys/fs/cgroup:/hostfs/sys/fs/cgroup:ro"
+      - "/proc:/hostfs/proc:ro"
+      - "/:/hostfs:ro"
+    environment:
+      - ELASTIC_USER=elastic
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTIC_HOSTS=https://es01:9200
+      - KIBANA_HOSTS=http://kibana:5601
+      - LOGSTASH_HOSTS=http://logstash01:9600
+
+  logstash01:
+    depends_on:
+      es01:
+        condition: service_healthy
+      kibana:
+        condition: service_healthy
+    image: docker.elastic.co/logstash/logstash:${STACK_VERSION}
+    labels:
+      co.elastic.logs/module: logstash
+    user: root
+    volumes:
+      - certs:/usr/share/logstash/certs
+      - logstashdata01:/usr/share/logstash/data
+      - "./logstash_ingest_data/:/usr/share/logstash/ingest_data/"
+      - "./logstash.conf:/usr/share/logstash/pipeline/logstash.conf:ro"
+    environment:
+      - xpack.monitoring.enabled=false
+      - ELASTIC_USER=elastic
+      - ELASTIC_PASSWORD=${ELASTIC_PASSWORD}
+      - ELASTIC_HOSTS=https://es01:9200
+
+volumes:
+  certs:
+    driver: local
+  esdata01:
+    driver: local
+  kibanadata:
+    driver: local
+  metricbeatdata01:
+    driver: local
+  logstashdata01:
+    driver: local
 
 networks:
   evotp3api:

--- a/evotp3api/src/main/resources/log4j2.xml
+++ b/evotp3api/src/main/resources/log4j2.xml
@@ -18,16 +18,10 @@
             </Policies>
         </RollingFile>
 
-        <!--<Console name="JsonAppender" fileName="./logs/profiling-log.json">
-            <JsonTemplateLayout />
-        </Console>-->
-
         <RollingFile name="RollingFile"
-                     fileName="/logs/app-log.log"
-                     filePattern="/logs/$${date:yyyy-MM}/app-log-%d{dd-MM-yyyy}-%i.log">
-            <PatternLayout>
-                <pattern>%d %p %C{1} [%t] %m%n</pattern>
-            </PatternLayout>
+                     fileName="/logs/app-log.json"
+                     filePattern="/logs/$${date:yyyy-MM}/app-log-%d{dd-MM-yyyy}-%i.json">
+            <JsonTemplateLayout />
             <Policies>
                 <!-- rollover on startup, daily and when the file reaches
                     10 MegaBytes -->

--- a/filebeat.yml
+++ b/filebeat.yml
@@ -1,0 +1,25 @@
+filebeat.inputs:
+  - type: filestream
+    id: default-filestream
+    paths:
+      - ingest_data/*.log
+
+# filebeat.autodiscover:
+#   providers:
+#     - type: docker
+#       hints.enabled: true
+
+processors:
+  - add_docker_metadata: ~
+
+setup.kibana:
+  host: ${KIBANA_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+
+output.elasticsearch:
+  hosts: ${ELASTIC_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+  ssl.enabled: true
+  ssl.certificate_authorities: "certs/ca/ca.crt"

--- a/logstash.conf
+++ b/logstash.conf
@@ -1,0 +1,49 @@
+input {
+  # PostgreSQL logs (single file)
+  file {
+    mode => "tail"
+    path => "/usr/share/logstash/ingest_data/database/postgresql.json"  # Absolute path to the PostgreSQL log
+    start_position => "beginning"
+    sincedb_path => "/usr/share/logstash/data/sincedb_postgresql"
+    codec => json  # JSON codec for structured data
+    type => "database"
+  }
+
+  # Spring Boot general logs (app-log.log)
+  file {
+    mode => "tail"
+    path => "/usr/share/logstash/ingest_data/backend/app-log.json"  # Absolute path to the general Spring log
+    start_position => "beginning"
+    sincedb_path => "/usr/share/logstash/data/sincedb_app_log"
+    codec => json  # JSON codec for structured data
+    type => "backend"
+  }
+
+  # User action logs (profiling-log.json)
+  file {
+    mode => "tail"
+    path => "/usr/share/logstash/ingest_data/backend/profiling-log.json"  # Absolute path to profiling log
+    start_position => "beginning"
+    sincedb_path => "/usr/share/logstash/data/sincedb_profiling_log"
+    codec => json  # JSON codec for structured data
+    type => "profiling"
+  }
+}
+
+filter {
+}
+
+output {
+  elasticsearch {
+    index => "logstash-%{+YYYY.MM.dd}"  # Index name pattern
+    hosts => "${ELASTIC_HOSTS}"
+    user => "${ELASTIC_USER}"
+    password => "${ELASTIC_PASSWORD}"
+    cacert => "certs/ca/ca.crt"
+  }
+
+  # Optional: Debug output to stdout to verify log parsing (remove in production)
+  stdout {
+    codec => rubydebug
+  }
+}

--- a/metricbeat.yml
+++ b/metricbeat.yml
@@ -1,0 +1,56 @@
+metricbeat.config.modules:
+  path: ${path.config}/modules.d/*.yml
+  reload.enabled: false
+
+metricbeat.modules:
+  - module: elasticsearch
+    xpack.enabled: true
+    period: 10s
+    hosts: ${ELASTIC_HOSTS}
+    ssl.certificate_authorities: "certs/ca/ca.crt"
+    ssl.certificate: "certs/es01/es01.crt"
+    ssl.key: "certs/es01/es01.key"
+    username: ${ELASTIC_USER}
+    password: ${ELASTIC_PASSWORD}
+    ssl.enabled: true
+
+  - module: logstash
+    xpack.enabled: true
+    period: 10s
+    hosts: ${LOGSTASH_HOSTS}
+
+  - module: kibana
+    metricsets:
+      - stats
+    period: 10s
+    hosts: ${KIBANA_HOSTS}
+    username: ${ELASTIC_USER}
+    password: ${ELASTIC_PASSWORD}
+    xpack.enabled: true
+
+  - module: docker
+    metricsets:
+      - "container"
+      - "cpu"
+      - "diskio"
+      - "healthcheck"
+      - "info"
+      #- "image"
+      - "memory"
+      - "network"
+    hosts: ["unix:///var/run/docker.sock"]
+    period: 10s
+    enabled: true
+
+processors:
+  - add_host_metadata: ~
+  - add_docker_metadata: ~
+
+output.elasticsearch:
+  hosts: ${ELASTIC_HOSTS}
+  username: ${ELASTIC_USER}
+  password: ${ELASTIC_PASSWORD}
+  ssl:
+    certificate: "certs/es01/es01.crt"
+    certificate_authorities: "certs/ca/ca.crt"
+    key: "certs/es01/es01.key"


### PR DESCRIPTION
## Description
This PR implements an Elastic stack for centralized logging and monitoring, following the official ELK tutorial[^1] and extending it with additional services. The setup includes Elasticsearch, Kibana, Metricbeat, and Logstash, configured to collect, process, and analyze logs from our Spring Boot application and PostgreSQL database.

## Added Services
- `es01`: The primary Elasticsearch node, responsible for indexing, storing, and retrieving log data.
- `kibana`: The front-end interface for visualizing and exploring data stored in Elasticsearch.
- `metricbeat01`: Collect system-level statistics (CPU, memory, disk usage) and specific container metrics and forwards these metrics directly to Elasticsearch for analysis and visualization in Kibana.
- `logstash01`: The centralized log aggregator and processor. It ingests the following logs from the `logstash_ingest_data` directory (which is mounted as a Docker volume):
  -  `database/postgresql.json`: all database logs
  -  `backend/app-log.json`: general backend logs
  -  `backend/profiling-log.json`: user profiling logs

## Usage
Simply run the following command:
```bash
docker-compose up --build
```

You can access the Kibana interface at [http://localhost:5601](http://localhost:5601) using the default username `elastic` and the password provided in the `.env` file.

## Other information
- Changed `evotp3apidb` service (the database) and `evotp3api` (the backend app) log format to JSON. Every log retrieved is now in JSON. This makes their processing faster.

[^1]: https://www.elastic.co/blog/getting-started-with-the-elastic-stack-and-docker-compose/